### PR TITLE
Add password handling to Collabora installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# nexiosoluti
+# NexioSoluti
+
+## Collabora Installer
+
+Use `install_collabora.bat` to load the Collabora database schema.
+
+```
+install_collabora.bat <path-to-sql-dump> [mysql_password]
+```
+
+* Provide the SQL dump as the first argument.
+* Optionally pass the MySQL password as the second argument. When supplied, the
+  script exports the value to `MYSQL_PWD` and runs `mysql` with
+  `--password=%MYSQL_PWD%` so the import remains fully unattended.
+* If the password argument is omitted, the script falls back to prompting for
+  the password interactively. Press **Enter** to leave it blank.
+* You can also predefine the `MYSQL_PWD` environment variable to avoid both the
+  argument and the prompt.
+
+The script defaults to connecting to `localhost` with the `root` user and the
+`collabora` database. Override these defaults by setting the `MYSQL_HOST`,
+`MYSQL_USER`, or `MYSQL_DATABASE` environment variables before running the
+installer.

--- a/install_collabora.bat
+++ b/install_collabora.bat
@@ -1,0 +1,49 @@
+@echo off
+setlocal enableextensions enabledelayedexpansion
+
+REM ==============================================================================
+REM  NexioSolution Collabora Office Installer
+REM  Usage: install_collabora.bat <sql_dump_path> [mysql_password]
+REM  - Provide the SQL dump path as the first argument.
+REM  - Optionally provide the MySQL user password as the second argument, or
+REM    leave it out to be prompted interactively.
+REM  - The password (whether provided as an argument, via the MYSQL_PWD
+REM    environment variable, or entered interactively) is passed to the mysql
+REM    client using --password=%MYSQL_PWD% so that no interactive prompt appears
+REM    during unattended installs.
+REM ==============================================================================
+
+set "SCRIPT_NAME=%~nx0"
+
+if "%~1"=="" (
+    echo Usage: %SCRIPT_NAME% ^<sql_dump_path^> [mysql_password]
+    exit /b 1
+)
+
+set "SQL_DUMP=%~1"
+if not exist "%SQL_DUMP%" (
+    echo [ERROR] SQL dump file "%SQL_DUMP%" was not found.
+    exit /b 1
+)
+
+if "%~2" NEQ "" (
+    set "MYSQL_PWD=%~2"
+) else if not defined MYSQL_PWD (
+    set /p "MYSQL_PWD=Enter MySQL password (leave blank for none): "
+)
+
+if not defined MYSQL_HOST set "MYSQL_HOST=localhost"
+if not defined MYSQL_USER set "MYSQL_USER=root"
+if not defined MYSQL_DATABASE set "MYSQL_DATABASE=collabora"
+
+set "PASSWORD_FLAG=--password=%MYSQL_PWD%"
+
+echo Importing Collabora database into %MYSQL_DATABASE% on %MYSQL_HOST% as %MYSQL_USER%...
+mysql --host=%MYSQL_HOST% --user=%MYSQL_USER% %PASSWORD_FLAG% --database=%MYSQL_DATABASE% < "%SQL_DUMP%"
+if errorlevel 1 (
+    echo [ERROR] Collabora database import failed.
+    exit /b 1
+)
+
+echo Collabora database import completed successfully.
+exit /b 0


### PR DESCRIPTION
## Summary
- add unattended password handling to `install_collabora.bat`, supporting an optional argument or prompt and passing the value to MySQL with `--password=%MYSQL_PWD%`
- document the installer usage and password behaviour in the README so operators know how to supply credentials

## Testing
- `printf '\r\n' | wine cmd /c "cd /d Z:\workspace\nexiosoluti & set PATH=Z:\workspace\nexiosoluti\test-bin;%PATH% & install_collabora.bat dump.sql"`
- `wine cmd /c "cd /d Z:\workspace\nexiosoluti & set PATH=Z:\workspace\nexiosoluti\test-bin;%PATH% & install_collabora.bat dump.sql secret"`


------
https://chatgpt.com/codex/tasks/task_e_68cffa7a9a90832e9712500d6cff8ac5